### PR TITLE
Do not override already set conn.assigns.csp_nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.1
+
+Added functionality to help with testing: does not set a new nonce if one has already been set.
+DO NOT set your own nonces in any case other than for tests or you will open a security hole.
+
 # 1.0.0
 
 Initial Release

--- a/lib/content_security_policy/plug/add_nonce.ex
+++ b/lib/content_security_policy/plug/add_nonce.ex
@@ -53,6 +53,7 @@ defmodule ContentSecurityPolicy.Plug.AddNonce do
     opts
   end
 
+  def call(%{assigns: %{csp_nonce: nonce}} = conn, opts), do: conn
   def call(conn, opts) do
     directives = opts
                  |> Keyword.get(:directives, @default_directives)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ContentSecurityPolicy.MixProject do
   def project do
     [
       app: :content_security_policy,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/content_security_policy/plug/add_nonce_test.exs
+++ b/test/content_security_policy/plug/add_nonce_test.exs
@@ -16,6 +16,15 @@ defmodule ContentSecurityPolicy.Plug.AddNonceTest do
     |> send_resp(200, "ok")
   end
 
+  defp send_response_with_preset_nonce(add_nonce_plug_opts \\ [], preset_nonce) do
+    :post
+    |> conn("/foo")
+    |> Map.merge(%{assigns: %{csp_nonce: preset_nonce}})
+    |> Setup.call([default_policy: %Policy{}])
+    |> AddNonce.call(add_nonce_plug_opts)
+    |> send_resp(200, "ok")
+  end
+
   describe "call/2" do
     test "adds a nonce to the default_src directive by default" do
       conn = send_response()
@@ -67,6 +76,14 @@ defmodule ContentSecurityPolicy.Plug.AddNonceTest do
         |> AddNonce.call([])
         |> send_resp(200, "ok")
       end)
+    end
+
+    test "does not set a new nonce if one has already been set" do
+
+      conn = send_response_with_preset_nonce([], "testnonce")
+      csp_nonce = conn.assigns[:csp_nonce]
+
+      assert csp_nonce == "testnonce"
     end
   end
 end


### PR DESCRIPTION
Helps with writing tests that compare against different renderings of the same page.